### PR TITLE
Fix issues with newlines in grammar .txt files

### DIFF
--- a/fix_lines.pl
+++ b/fix_lines.pl
@@ -1,0 +1,22 @@
+#read stdin as a single string and not a line at a time
+my $whole_file; { local $/; $whole_file = <STDIN> };
+
+# line wrapped in the middle of reference <like this>
+# This:
+# some text <about
+#    a thing> really references <about a thing>
+# Turns into:
+# some text <about a thing> really references <about a thing>
+#
+# first capture group gets an unclosed < that looks like a reference
+# then uncaptured whitespace around a newline
+# second capture group gets the rest of the reference and its closing >
+# the replacement has a space in the middle to replace the whitespace that was a newline
+$whole_file =~ s/(<[a-z][a-zA-Z: ]*)\s*\n\s*([a-zA-Z: ]+[a-z]>)/$1 $2/g;
+
+# remove linebreaks in paragraph text that put a reference at the beginning of a line
+# the only allowed references at the beginning of the line are actual definitions with ::= on the same line
+$whole_file =~ s/(\w)\s*\n(<[a-z][a-zA-Z: ]+[a-z]>(?!.*::=))/$1 $2/g;
+
+# print the processed file back out for further processing
+print $whole_file;

--- a/make_website.sh
+++ b/make_website.sh
@@ -13,5 +13,5 @@ gta="runhaskell -package-db=.cabal-sandbox/x86_64-linux-ghc-8.6.5-packages.conf.
 
 for i in sql-92-grammar sql-1999-grammar sql-2003-foundation-grammar sql-2008-foundation-grammar sql-2011-foundation-grammar sql-2011-psm-grammar sql-2016-foundation-grammar; do
     echo $i
-    cat $i.txt | $gta | asciidoctor - | runhaskell AddLinks.lhs > build/$i.html
+    perl fix_lines.pl < $i.txt | $gta | asciidoctor - | runhaskell AddLinks.lhs > build/$i.html
 done


### PR DESCRIPTION
Newlines in the middle of text blocks break <references like this> and they can also result in a reference in the middle of a paragraph coincidentally starting a line and looking like a definition not a reference.

Implemented in perl because that was easiest for me but should be translated to haskell by someone who knows haskell.